### PR TITLE
Improve ActingAsKeycloakUser trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ Auth::hasAnyScope(['scope-f', 'scope-k']) // false
 
 # Acting as a Keycloak user in tests
 
-As an equivelant feature like `$this->actingAs($user)` in Laravel, with this package you can use `KeycloakGuard\ActingAsKeycloakUser` trait in your test class and then use `actingAsKeycloakUser()` method to act as a user and somehow skip the Keycloak auth:
+As an equivalent feature like `$this->actingAs($user)` in Laravel, with this package you can use `KeycloakGuard\ActingAsKeycloakUser` trait in your test class and then use `actingAsKeycloakUser()` method to act as a user and somehow skip the Keycloak auth:
 
 ```php
 use KeycloakGuard\ActingAsKeycloakUser;
@@ -345,6 +345,22 @@ public test_a_protected_route()
 ```
 
 If you are not using `keycloak.load_user_from_database` option, set `keycloak.preferred_username` with a valid `preferred_username` for tests.
+
+You can also specify exact expectations for the token payload by passing the payload array in the second argument:
+
+```php
+use KeycloakGuard\ActingAsKeycloakUser;
+
+public test_a_protected_route()
+{
+    $this->actingAsKeycloakUser($user, [
+        'aud' => 'account',
+        'exp' => 1715926026,
+        'iss' => 'https://localhost:8443/realms/master'
+    ])->getJson('/api/somewhere')
+      ->assertOk();
+}
+```
 
 # Contribute
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "prefer-stable": true,
     "require": {
         "firebase/php-jwt": "^6.3",
-        "php": "^8.0"
+        "php": "^8.0",
+        "ext-openssl": "*"
     },
     "autoload": {
         "psr-4": {

--- a/src/ActingAsKeycloakUser.php
+++ b/src/ActingAsKeycloakUser.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Config;
 
 trait ActingAsKeycloakUser
 {
-    public function actingAsKeycloakUser($user = null, $payload = [])
+    public function actingAsKeycloakUser($user = null, $payload = []): self
     {
         if (!$user) {
             Config::set('keycloak.load_user_from_database', false);
@@ -20,7 +20,7 @@ trait ActingAsKeycloakUser
         return $this;
     }
 
-    public function generateKeycloakToken($user = null, $payload = [])
+    public function generateKeycloakToken($user = null, $payload = []): string
     {
         $privateKey = openssl_pkey_new([
             'digest_alg' => 'sha256',
@@ -41,6 +41,7 @@ trait ActingAsKeycloakUser
         $principal = Config::get('keycloak.token_principal_attribute');
         $credential = Config::get('keycloak.user_provider_credential');
         $payload = array_merge([
+            'iss' => 'https://keycloak.server/realms/laravel',
             'iat' => $iat,
             'exp' => $exp,
             $principal => is_string($user) ? $user : $user->$credential ?? config('keycloak.preferred_username'),


### PR DESCRIPTION
The aim of the change is to allow passing custom claims to the test token as well as adding widely accepted claims by default.