### PR TITLE
Improve ActingAsKeycloakUser trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,34 @@ public test_a_protected_route()
 }
 ```
 
+Whatever you pass in the payload will override default claims,
+which includes `aud`, `iat`, `exp`, `iss`, `azp`, `resource_access` and either `sub` or `preferred_username`,
+depending on **token_principal_attribute** config.
+
+Alternatively, payload can be provided in a class property, so it can be reused across multiple tests:
+
+```php
+use KeycloakGuard\ActingAsKeycloakUser;
+
+protected $tokenPayload = [
+    'aud' => 'account',
+    'exp' => 1715926026,
+    'iss' => 'https://localhost:8443/realms/master'
+];
+
+public test_a_protected_route()
+{
+    $payload = [
+        'exp' => 1715914352
+    ];
+    $this->actingAsKeycloakUser($user, $payload)
+        ->getJson('/api/somewhere')
+        ->assertOk();
+}
+```
+
+Priority is given to the claims in passed as an argument, so they will override ones in the class property.
+
 # Contribute
 
 You can run this project on VSCODE with Remote Container. Make sure you will use internal VSCODE terminal (inside running container).

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ Auth::hasAnyScope(['scope-f', 'scope-k']) // false
 
 # Acting as a Keycloak user in tests
 
-As an equivelant feature like `$this->actingAs($user)` in Laravel, with this package you can use `KeycloakGuard\ActingAsKeycloakUser` trait in your test class and then use `actingAsKeycloakUser()` method to act as a user and somehow skip the Keycloak auth:
+As an equivalent feature like `$this->actingAs($user)` in Laravel, with this package you can use `KeycloakGuard\ActingAsKeycloakUser` trait in your test class and then use `actingAsKeycloakUser()` method to act as a user and somehow skip the Keycloak auth:
 
 ```php
 use KeycloakGuard\ActingAsKeycloakUser;
@@ -345,6 +345,22 @@ public test_a_protected_route()
 ```
 
 If you are not using `keycloak.load_user_from_database` option, set `keycloak.preferred_username` with a valid `preferred_username` for tests.
+
+You can also specify exact expectations for the token payload by passing the payload array in the second argument:
+
+```php
+use KeycloakGuard\ActingAsKeycloakUser;
+
+public test_a_protected_route()
+{
+    $this->actingAsKeycloakUser($user, [
+        'aud' => 'account',
+        'exp' => 1715926026,
+        'iss' => 'https://localhost:8443/realms/master'
+    ])->getJson('/api/somewhere')
+      ->assertOk();
+}
+```
 
 # Contribute
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "prefer-stable": true,
     "require": {
         "firebase/php-jwt": "^6.3",
-        "php": "^8.0"
+        "php": "^8.0",
+        "ext-openssl": "*"
     },
     "autoload": {
         "psr-4": {

--- a/src/ActingAsKeycloakUser.php
+++ b/src/ActingAsKeycloakUser.php
@@ -7,6 +7,8 @@ use Illuminate\Support\Facades\Config;
 
 trait ActingAsKeycloakUser
 {
+    protected array $payload = [];
+
     public function actingAsKeycloakUser($user = null, $payload = []): self
     {
         if (!$user) {
@@ -37,7 +39,6 @@ trait ActingAsKeycloakUser
         $iat = time();
         $exp = time() + 300;
         $resourceAccess = [config('keycloak.allowed_resources') => []];
-
         $principal = Config::get('keycloak.token_principal_attribute');
         $credential = Config::get('keycloak.user_provider_credential');
         $payload = array_merge([
@@ -47,8 +48,8 @@ trait ActingAsKeycloakUser
             'iat' => $iat,
             'exp' => $exp,
             $principal => is_string($user) ? $user : $user->$credential ?? config('keycloak.preferred_username'),
-            'resource_access' => $resourceAccess
-        ], $payload);
+            'resource_access' => $resourceAccess,
+        ], $this->payload, $payload);
 
         return JWT::encode($payload, $privateKey, 'RS256');
     }

--- a/src/ActingAsKeycloakUser.php
+++ b/src/ActingAsKeycloakUser.php
@@ -11,7 +11,8 @@ trait ActingAsKeycloakUser
 
     public function actingAsKeycloakUser($user = null, $payload = []): self
     {
-        if (!$user) {
+        $principal = Config::get('keycloak.token_principal_attribute');
+        if (!$user && !isset($payload[$principal]) && !isset($this->payload[$principal])) {
             Config::set('keycloak.load_user_from_database', false);
         }
 

--- a/src/ActingAsKeycloakUser.php
+++ b/src/ActingAsKeycloakUser.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Config;
 
 trait ActingAsKeycloakUser
 {
-    public function actingAsKeycloakUser($user = null, $payload = [])
+    public function actingAsKeycloakUser($user = null, $payload = []): self
     {
         if (!$user) {
             Config::set('keycloak.load_user_from_database', false);
@@ -20,7 +20,7 @@ trait ActingAsKeycloakUser
         return $this;
     }
 
-    public function generateKeycloakToken($user = null, $payload = [])
+    public function generateKeycloakToken($user = null, $payload = []): string
     {
         $privateKey = openssl_pkey_new([
             'digest_alg' => 'sha256',
@@ -41,6 +41,7 @@ trait ActingAsKeycloakUser
         $principal = Config::get('keycloak.token_principal_attribute');
         $credential = Config::get('keycloak.user_provider_credential');
         $payload = array_merge([
+            'iss' => 'https://keycloak.server/realms/laravel',
             'iat' => $iat,
             'exp' => $exp,
             $principal => is_string($user) ? $user : $user->$credential ?? config('keycloak.preferred_username'),

--- a/src/ActingAsKeycloakUser.php
+++ b/src/ActingAsKeycloakUser.php
@@ -42,6 +42,8 @@ trait ActingAsKeycloakUser
         $credential = Config::get('keycloak.user_provider_credential');
         $payload = array_merge([
             'iss' => 'https://keycloak.server/realms/laravel',
+            'azp' => 'client-id',
+            'aud' => 'phpunit',
             'iat' => $iat,
             'exp' => $exp,
             $principal => is_string($user) ? $user : $user->$credential ?? config('keycloak.preferred_username'),

--- a/tests/AuthenticateTest.php
+++ b/tests/AuthenticateTest.php
@@ -462,7 +462,7 @@ class AuthenticateTest extends TestCase
             $arg = $payload;
         }
 
-        $this->actingAsKeycloakUser($this->user, $arg)->json('GET', '/foo/secret');
+        $this->actingAsKeycloakUser(payload: $arg)->json('GET', '/foo/secret');
 
         $this->assertEquals('test_username', Auth::user()->username);
         $token = Token::decode(request()->bearerToken(), config('keycloak.realm_public_key'), config('keycloak.leeway'), config('keycloak.token_encryption_algorithm'));
@@ -470,6 +470,7 @@ class AuthenticateTest extends TestCase
         $this->assertEquals(9999999999999, $token->exp);
         $this->assertEquals('test_sub', $token->sub);
         $this->assertEquals('test_aud', $token->aud);
+        $this->assertTrue(config('keycloak.load_user_from_database'));
     }
 
     public function test_acting_as_keycloak_user_trait_without_user()

--- a/tests/AuthenticateTest.php
+++ b/tests/AuthenticateTest.php
@@ -420,6 +420,9 @@ class AuthenticateTest extends TestCase
         $token = Token::decode(request()->bearerToken(), config('keycloak.realm_public_key'), config('keycloak.leeway'), config('keycloak.token_encryption_algorithm'));
         $this->assertNotNull($token->iat);
         $this->assertNotNull($token->exp);
+        $this->assertNotNull($token->iss);
+        $this->assertNotNull($token->azp);
+        $this->assertNotNull($token->aud);
     }
 
     public function test_with_keycloak_token_trait_with_username()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -21,6 +21,8 @@ class TestCase extends Orchestra
     public array $defaultPayload;
     public string $token;
 
+    protected User $user;
+
     protected function setUp(): void
     {
         // Prepare credentials

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -18,7 +18,7 @@ class TestCase extends Orchestra
 {
     public OpenSSLAsymmetricKey $privateKey;
     public string $publicKey;
-    public array $payload;
+    public array $defaultPayload;
     public string $token;
 
     protected function setUp(): void
@@ -53,12 +53,12 @@ class TestCase extends Orchestra
 
         $this->publicKey = openssl_pkey_get_details($this->privateKey)['key'];
 
-        $this->payload = [
+        $this->defaultPayload = [
             'preferred_username' => 'johndoe',
             'resource_access' => ['myapp-backend' => []]
         ];
 
-        $this->token = JWT::encode($this->payload, $this->privateKey, $encryptionAlgorithm);
+        $this->token = JWT::encode($this->defaultPayload, $this->privateKey, $encryptionAlgorithm);
     }
 
     // Default configs to make it running
@@ -102,7 +102,7 @@ class TestCase extends Orchestra
     // Build a different token with custom payload
     protected function buildCustomToken(array $payload, string $encryptionAlgorithm = 'RS256')
     {
-        $payload = array_replace($this->payload, $payload);
+        $payload = array_replace($this->defaultPayload, $payload);
 
         $this->token = JWT::encode($payload, $this->privateKey, $encryptionAlgorithm);
     }


### PR DESCRIPTION
The aim of the change is to allow passing custom claims to the test token as well as adding widely accepted claims by default.